### PR TITLE
lock xmldom dependency to 0.1.19

### DIFF
--- a/index.js
+++ b/index.js
@@ -165,7 +165,7 @@
 
         for (var sName in oParentObj) {
 	  vValue = oParentObj[sName];
-	  if (!vValue) vValue = {};
+	  if (vValue === null) vValue = {};
           if (isFinite(sName) || vValue instanceof Function) { continue; } /* verbosity level is 0 */
           // when it is _
           if (sName === sValProp) {

--- a/index.js
+++ b/index.js
@@ -164,7 +164,8 @@
         }
 
         for (var sName in oParentObj) {
-          vValue = oParentObj[sName];
+	  vValue = oParentObj[sName];
+	  if (!vValue) vValue = {};
           if (isFinite(sName) || vValue instanceof Function) { continue; } /* verbosity level is 0 */
           // when it is _
           if (sName === sValProp) {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "license": "GPL v3",
   "dependencies": {
-    "xmldom": "~0.1.17"
+    "xmldom": "0.1.19"
   },
   "devDependencies": {
     "mocha": "~2.1.0",


### PR DESCRIPTION
Hi there,
xmldoc got updated to 0.1.20 over the weekend and this library is no longer working for me. Locking to 0.1.19 until we can find out why the dependency issue. 
