### PR TITLE
Fixes broken AMD registration

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@
 (function (root, factory) {
     if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
-        define(factory(window));
+        define([], factory(window));
     } else if (typeof exports === 'object') {
         if (typeof window === 'object' && window.DOMImplementation) {
             // Browserify. hardcode usage of browser's own XMLDom implementation


### PR DESCRIPTION
I am not sure if it worked okay before in browsers, but r.js and almond
gave me all kinds of trouble until I changed this.