### PR TITLE
Add control over vValue to check if it's undefined, not only null

### DIFF
--- a/jxon.js
+++ b/jxon.js
@@ -231,7 +231,10 @@
       for (var sName in oParentObj) {
 
         vValue = oParentObj[sName];
-        if ( vValue === undefined || vValue === null ) {
+        if ( vValue === undefined ) {
+          continue;
+        }
+        if ( vValue === null ) {
           vValue = {};
         }
 

--- a/jxon.js
+++ b/jxon.js
@@ -231,7 +231,7 @@
       for (var sName in oParentObj) {
 
         vValue = oParentObj[sName];
-        if (vValue === null) {
+        if ( vValue === undefined || vValue === null ) {
           vValue = {};
         }
 


### PR DESCRIPTION
There are some problems when I try to convert a JS to XML when the fields are undefined.

There are a error control only for null values, I implement a new contrl for undefined values.
