### PR TITLE
Fix Browserify assumption

### DIFF
--- a/jxon.js
+++ b/jxon.js
@@ -28,7 +28,7 @@
     // AMD. Register as an anonymous module.
     define([], factory(window));
   } else if (typeof exports === 'object') {
-    if (typeof window === 'object' && window.DOMImplementation) {
+    if (typeof window === 'object' && window.DOMImplementation && window.XMLSerializer && window.DOMParser) {
       // Browserify. hardcode usage of browser's own XMLDom implementation
       // see https://github.com/tyrasd/jxon/issues/18
 


### PR DESCRIPTION
While testing a module I wrote that depends on jxon, I came across a bug.

Apparently, when testing with Jest, a `window.DOMImplementation` is defined. However, a `window.XMLSerializer` is not. So rather than assume that Browserify is running if only the former is defined, it may be better to check for all the dependencies that the `xmlDom` object will use.

I am not familiar with Browserify or the issue that propmted the addition of those lines of code in the first place, but I do know that making this change allowed me to continue testing in Node using Jest without failure.