### PR TITLE
Support namespace prefixes

### DIFF
--- a/jxon.js
+++ b/jxon.js
@@ -239,6 +239,19 @@
       return elementNS || oParentEl.namespaceURI;
     }
 
+    function setAttribute(sAttrib, vValue, oParentEl) {
+      var attributeNS, 
+        prefix;
+
+      if (sAttrib.indexOf(':') !== -1) {
+        prefix = sAttrib.split(':')[0];
+        attributeNS = oParentEl.lookupNamespaceURI(prefix) || oParentEl.namespaceURI;
+        oParentEl.setAttributeNS(attributeNS, sAttrib, vValue);
+      } else {
+        oParentEl.setAttribute(sAttrib, vValue);
+      }
+    }
+
     function createElement(sName, vValue, oParentEl, oXMLDoc) {
       var elementNS = getElementNS(sName, vValue, oParentEl),
         element;        
@@ -287,13 +300,13 @@
 
         } else if (sName === opts.attrKey) { /* verbosity level is 3 */
           for (var sAttrib in vValue) {
-            oParentEl.setAttribute(sAttrib, vValue[sAttrib]);
+            setAttribute(sAttrib, vValue[sAttrib], oParentEl);
           }
         } else if (sName.indexOf(opts.attrPrefix + 'xmlns') === 0) {
           // explicitly set xmlns and xmlns:* attributes, so they can be set anywhere in the tag hierarchy
           oParentEl.setAttributeNS('http://www.w3.org/2000/xmlns/', sName.slice(1), vValue);
         } else if (sName.charAt(0) === opts.attrPrefix) {
-          oParentEl.setAttribute(sName.slice(1), vValue);
+          setAttribute(sName.slice(1), vValue, oParentEl);
         } else if (vValue.constructor === Array) {
           for (var nItem in vValue) {
             if (!vValue.hasOwnProperty(nItem)) continue;

--- a/jxon.js
+++ b/jxon.js
@@ -214,10 +214,33 @@
 
       return vResult;
     }
+
+    function getElementNS(value, oParentEl) {
+      var elementNS;
+
+      if (value && typeof value === 'object') {
+        elementNS = value[opts.attrPrefix + 'xmlns'];
+      }
+
+      return elementNS || oParentEl.namespaceURI;
+    }
+
+    function createElement(sName, value, oParentEl, oXMLDoc) {
+      var elementNS = getElementNS(value, oParentEl),
+        element;        
+
+      if (elementNS) {
+        element = oXMLDoc.createElementNS(elementNS, sName);
+      } else {
+        element = oXMLDoc.createElement(sName);
+      }
+
+      return element;
+    }
+
     function loadObjTree(oXMLDoc, oParentEl, oParentObj) {
       var vValue,
-        oChild,
-        elementNS;
+        oChild;
 
       if (oParentObj.constructor === String || oParentObj.constructor === Number || oParentObj.constructor === Boolean) {
         oParentEl.appendChild(oXMLDoc.createTextNode(oParentObj.toString())); /* verbosity level is 0 or 1 */
@@ -262,23 +285,13 @@
         } else if (vValue.constructor === Array) {
           for (var nItem in vValue) {
             if (!vValue.hasOwnProperty(nItem)) continue;
-            elementNS = (vValue[nItem] && vValue[nItem][opts.attrPrefix + 'xmlns']) || oParentEl.namespaceURI;
-            if (elementNS) {
-              oChild = oXMLDoc.createElementNS(elementNS, sName);
-            } else {
-              oChild = oXMLDoc.createElement(sName);
-            }
+            oChild = createElement(sName, vValue[nItem], oParentEl, oXMLDoc);
 
             loadObjTree(oXMLDoc, oChild, vValue[nItem] || {});
             oParentEl.appendChild(oChild);
           }
         } else {
-          elementNS = (vValue || {})[opts.attrPrefix + 'xmlns'] || oParentEl.namespaceURI;
-          if (elementNS) {
-            oChild = oXMLDoc.createElementNS(elementNS, sName);
-          } else {
-            oChild = oXMLDoc.createElement(sName);
-          }
+          oChild = createElement(sName, vValue, oParentEl, oXMLDoc);
           if (vValue instanceof Object) {
             loadObjTree(oXMLDoc, oChild, vValue);
           } else if (vValue !== null && (vValue !== true || !opts.trueIsEmpty)) {

--- a/jxon.js
+++ b/jxon.js
@@ -151,27 +151,6 @@
         vResult = nVerb === 0 ? objectify(vBuiltVal) : {};
       }
 
-      for (var nElId = nLevelStart; nElId < nLevelEnd; nElId++) {
-
-        sProp = aCache[nElId].nodeName;
-        if (opts.lowerCaseTags) {
-          sProp = sProp.toLowerCase();
-        }
-
-        vContent = createObjTree(aCache[nElId], nVerb, bFreeze, bNesteAttr);
-        if (vResult.hasOwnProperty(sProp)) {
-          if (vResult[sProp].constructor !== Array) {
-            vResult[sProp] = [vResult[sProp]];
-          }
-
-          vResult[sProp].push(vContent);
-        } else {
-          vResult[sProp] = vContent;
-
-          nLength++;
-        }
-      }
-
       if (bAttributes) {
         var nAttrLen = oParentNode.attributes.length,
           sAPrefix = bNesteAttr ? '' : opts.attrPrefix,
@@ -199,6 +178,27 @@
           nLength -= nAttrLen - 1;
         }
 
+      }
+
+      for (var nElId = nLevelStart; nElId < nLevelEnd; nElId++) {
+
+        sProp = aCache[nElId].nodeName;
+        if (opts.lowerCaseTags) {
+          sProp = sProp.toLowerCase();
+        }
+
+        vContent = createObjTree(aCache[nElId], nVerb, bFreeze, bNesteAttr);
+        if (vResult.hasOwnProperty(sProp)) {
+          if (vResult[sProp].constructor !== Array) {
+            vResult[sProp] = [vResult[sProp]];
+          }
+
+          vResult[sProp].push(vContent);
+        } else {
+          vResult[sProp] = vContent;
+
+          nLength++;
+        }
       }
 
       if (nVerb === 3 || (nVerb === 2 || nVerb === 1 && nLength > 0) && sCollectedTxt) {

--- a/test/spec.js
+++ b/test/spec.js
@@ -235,5 +235,24 @@ describe('JXON', function() {
       var str2 = JXON.jsToString(obj);
       assert.equal(str1, str2);
     });
+    it('sets the namespace for prefixed attributes', function() {
+      var obj = {
+        "element": {
+          "$xmlns": "urn:default",
+          "$xmlns:foo": "urn:foo",
+          "$foo:a": "bar"
+        }
+      };
+      var xml = JXON.jsToXml(obj);
+      var element = xml.documentElement;
+      var str = JXON.xmlToString(xml);
+      var attr = element.attributes[2];
+
+      assert.equal(attr.localName, 'a', 'localName');
+      assert.equal(attr.prefix, 'foo', 'prefix');
+      assert.equal(attr.namespaceURI, 'urn:foo', 'namespaceURI');
+      
+      assert.equal(str, '<element xmlns="urn:default" xmlns:foo="urn:foo" foo:a="bar"/>');
+    });
   });
 });

--- a/test/spec.js
+++ b/test/spec.js
@@ -192,5 +192,42 @@ describe('JXON', function() {
       var str = JXON.jsToString(obj);
       assert.equal(str, '<element><a xmlns="foo">1</a><a/><a xmlns="foo">3</a></element>');
     });
+    it('sets the corresponding parent namespace for prefix', function() {
+      var obj = {
+        root: {
+          "$xmlns": "urn:default",
+          "$xmlns:foo": "urn:foo",
+          element: {
+              "foo:a": "bar"
+          }
+        }
+      };
+      var xml = JXON.jsToXml(obj);
+      var a = xml.documentElement.firstChild.firstChild;
+      var str = JXON.xmlToString(xml);
+
+      assert.equal(a.localName, 'a', 'localName');
+      assert.equal(a.prefix, 'foo', 'prefix');
+      assert.equal(a.namespaceURI, 'urn:foo', 'namespaceURI');
+      
+      assert.equal(str, '<root xmlns="urn:default" xmlns:foo="urn:foo"><element><foo:a>bar</foo:a></element></root>');
+    });
+    it('sets the attribute namespace for prefix', function() {
+      var obj = {
+        "foo:element": {
+          "$xmlns:foo": "urn:foo",
+            "_": "bar"
+        }
+      };
+      var xml = JXON.jsToXml(obj);
+      var element = xml.documentElement;
+      var str = JXON.xmlToString(xml);
+
+      assert.equal(element.localName, 'element', 'localName');
+      assert.equal(element.prefix, 'foo', 'prefix');
+      assert.equal(element.namespaceURI, 'urn:foo', 'namespaceURI');
+      
+      assert.equal(str, '<foo:element xmlns:foo="urn:foo">bar</foo:element>');
+    });
   });
 });

--- a/test/spec.js
+++ b/test/spec.js
@@ -173,5 +173,24 @@ describe('JXON', function() {
 
       assert.equal(strNull, strEmptyObj);
     });
+    it('sets the namespace for array elements', function() {
+      var obj = {
+        "element": {
+          "a": [
+            {
+              "$xmlns": "foo",
+              "_": "1"
+            },
+            null,
+            {
+              "$xmlns": "foo",
+              "_": "3"
+            }
+          ]
+        }
+      };
+      var str = JXON.jsToString(obj);
+      assert.equal(str, '<element><a xmlns="foo">1</a><a/><a xmlns="foo">3</a></element>');
+    });
   });
 });

--- a/test/spec.js
+++ b/test/spec.js
@@ -229,5 +229,11 @@ describe('JXON', function() {
       
       assert.equal(str, '<foo:element xmlns:foo="urn:foo">bar</foo:element>');
     });
+    it('keeps prefix and namespace on XML round trip', function() {
+      var str1 = '<root xmlns="urn:default" xmlns:foo="urn:foo"><element><foo:a>bar</foo:a></element></root>';
+      var obj = JXON.stringToJs(str1);
+      var str2 = JXON.jsToString(obj);
+      assert.equal(str1, str2);
+    });
   });
 });


### PR DESCRIPTION
Fixes #52 by using [`lookupNamespaceURI`](https://developer.mozilla.org/en-US/docs/Web/API/Node/lookupNamespaceURI) and supporting changes.

Tested with current Chromium (89) and Firefox (86) on Ubuntu (not on IE or other browsers).

See [updated demo](http://plnkr.co/edit/mhGOEVfX4f0Rtpgb?open=lib%2Fscript.js&preview) that now has the `locus:` prefix in the XML string also.

Failing tests are in separate commits before fixes, so they can be checked out and seen failing (feel free to squash).

Includes the following changes:
- Refactoring of duplicate `createElement` and namespace retrieval code into functions
- For prefixed elements, the corresponding namespace is searched a) in the attributes of the current value, then b) in the parent element hierarchy by using [`lookupNamespaceURI`](https://developer.mozilla.org/en-US/docs/Web/API/Node/lookupNamespaceURI).
- For the lookup to work, the element hierarchy already needs to exist when procesing a value. Therefore `appendChild` is now done before recursing down (plugging together top down instead of bottom up).
- Relying on getting `xmlns` attributes handled automatically with `createElementNS` doesn't seem to work for all cases. So they are added explicitly now with `setAttributeNS` and their namespace [`http://www.w3.org/2000/xmlns/`](https://www.w3.org/2000/xmlns/), which is [needed for lookup](https://dom.spec.whatwg.org/#locate-a-namespace). This way, they can be set anywhere in the parent hierarchy of a prefixed element.
- Adds attributes first when creating an object tree from XML. This is needed for a round trip `stringToJs` -> `jsToString`, as the the namespace lookup needs the `xmlns` attributes to already exist in the document.

### Resources

- [Node.lookupNamespaceURI() (MDN)](https://developer.mozilla.org/en-US/docs/Web/API/Node/lookupNamespaceURI)
  - [DOM Standard - lookupNamespaceURI(prefix)](https://dom.spec.whatwg.org/#dom-node-lookupnamespaceuri)
- [A Namespace Name for xmlns Attributes](https://www.w3.org/2000/xmlns/)
- [Namespaces in XML](https://www.w3.org/TR/1999/REC-xml-names-19990114/)
