### PR TITLE
Replace deprecated xmldom with @xmldom/xmldom

### DIFF
--- a/jxon.js
+++ b/jxon.js
@@ -20,7 +20,7 @@
  * bugfixes and code cleanup by user @laubstein
  * https://github.com/tyrasd/jxon/pull/32
  *
- * adapted for nodejs and npm by @tyrasd (Martin Raifer <tyr.asd@gmail.com>) 
+ * adapted for nodejs and npm by @tyrasd (Martin Raifer <tyr.asd@gmail.com>)
  */
 
 (function(root, factory) {
@@ -38,7 +38,7 @@
       // only CommonJS-like environments that support module.exports,
       // like Node.
 
-      module.exports = factory(require('xmldom'), true);
+      module.exports = factory(require('@xmldom/xmldom'), true);
     }
   } else {
     // Browser globals (root is window)

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "license": "GPL v3",
   "dependencies": {
-    "xmldom": "^0.1.21"
+    "@xmldom/xmldom": "^0.7.5"
   },
   "devDependencies": {
     "browserify": "^13.0.0",

--- a/test/index.html
+++ b/test/index.html
@@ -9,7 +9,9 @@
   <body>
     <div id='mocha'></div>
     <script src='../node_modules/mocha/mocha.js'></script>
-    <script>mocha.setup('bdd')</script>
+    <script src='../node_modules/chai/chai.js'></script>
+    <script>mocha.ui('bdd')</script>
+    <script>expect = chai.expect</script>
     <script src='spec.browserify.js'></script>
     <script>
       window.mocha.run();


### PR DESCRIPTION
Should resolve the security issue reported in the deprecated xmldom package

```script
✔ 12:20 ~/src/github.com/geoffcorey/jxon [master|…2] $ npm test

> jxon@2.0.0-beta.5 pretest /home/geoff/src/github.com/geoffcorey/jxon
> npm ls --depth=Infinity > /dev/null


> jxon@2.0.0-beta.5 test /home/geoff/src/github.com/geoffcorey/jxon
> npm run test-node && npm run test-webkit


> jxon@2.0.0-beta.5 test-node /home/geoff/src/github.com/geoffcorey/jxon
> mocha test/spec.js



  JXON
    .jsToXml > .xmlToJs
      ✓ should return return identical object 
    .jsToString > .stringToJs
      ✓ should return return identical object 
    .stringToJs > .jsToString > .stringToJs
      ✓ should return return identical object 
    empty nodes should be empty when trueIsEmpty = false
      ✓ <empty/> should remain empty 
      ✓ <empty></empty> should remain empty 
    parseValues option
      ✓ 11.0 should remain string 
    json treatment
      ✓ treat null values equally as empty objects 
      ✓ deal with pure arrays with jumped indexes 
      ✓ ignores prototypal inherited properties of arrays 
      ✓ deal with pure arrays with jumped indexes and null values 
      ✓ skip undefined properties 
    .each
      ✓ one node should iterate 
      ✓ multiple nodes should iterate 
    xml namespaces
      ✓ should parse xmlns 
      ✓ as property 


  15 passing (16ms)


> jxon@2.0.0-beta.5 test-webkit /home/geoff/src/github.com/geoffcorey/jxon
> browserify test/spec.js > test/spec.browserify.js && mocha-phantomjs test/index.html



  JXON
    .jsToXml > .xmlToJs
      ✓ should return return identical object 
    .jsToString > .stringToJs
      ✓ should return return identical object 
    .stringToJs > .jsToString > .stringToJs
      ✓ should return return identical object 
    empty nodes should be empty when trueIsEmpty = false
      ✓ <empty/> should remain empty 
      ✓ <empty></empty> should remain empty 
    parseValues option
      ✓ 11.0 should remain string 
    json treatment
      ✓ treat null values equally as empty objects 
      ✓ deal with pure arrays with jumped indexes 
      ✓ ignores prototypal inherited properties of arrays 
      ✓ deal with pure arrays with jumped indexes and null values 
      ✓ skip undefined properties 
    .each
      ✓ one node should iterate 
      ✓ multiple nodes should iterate 
    xml namespaces
      ✓ should parse xmlns 
      ✓ as property 


  15 passing (10ms)
```